### PR TITLE
Fix for Oracle

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1458,7 +1458,7 @@ class Builder
         $this->backupFieldsForCount($grouped);
 
         if ($grouped) {
-            $this->from = $this->raw("({$selectSql}) as subquery");
+            $this->from = $this->raw("({$selectSql}) subquery");
         }
 
         $total = $this->count($columns);


### PR DESCRIPTION
Using Oracle driver, this does not work:

select count(*) as aggregate from (select distinct column1, column2, columnN from tablename) as subquery;

But this works in both, MySQL and Oracle:

select count(*) as aggregate from (select distinct column1, column2, columnN from tablename) subquery;